### PR TITLE
Add mdefp macro to generate private functions

### DIFF
--- a/lib/multi_def.ex
+++ b/lib/multi_def.ex
@@ -40,4 +40,26 @@ defmodule MultiDef do
       end
     end
   end
+
+  defmacro mdefp({name, _line, nil}, [do: clauses]) do
+    for {:->, _line, [args, body]} <- clauses do
+      case args do
+        [{:when, _, when_clause}] -> #[arglist, condition]}] ->
+          [ condition | rargs ] = Enum.reverse(when_clause)
+          arglist = Enum.reverse(rargs)
+          quote do
+            defp unquote(name)(unquote_splicing(arglist)) when(unquote(condition)) do
+              unquote(body)
+            end
+          end
+        _ ->
+          quote do
+            defp unquote(name)(unquote_splicing(args)) do
+              unquote(body)
+            end
+          end
+      end
+    end
+  end
+
 end

--- a/lib/multi_def.ex
+++ b/lib/multi_def.ex
@@ -21,45 +21,33 @@ defmodule MultiDef do
   Does not enforce that all heads have the same arity (deliberately).
   """
   defmacro mdef({name, _line, nil}, [do: clauses]) do
-    for {:->, _line, [args, body]} <- clauses do
-      case args do
-        [{:when, _, when_clause}] -> #[arglist, condition]}] ->
-          [ condition | rargs ] = Enum.reverse(when_clause)
-          arglist = Enum.reverse(rargs)
-          quote do
-            def unquote(name)(unquote_splicing(arglist)) when(unquote(condition)) do
-              unquote(body)
-            end
-          end
-        _ ->
-          quote do
-            def unquote(name)(unquote_splicing(args)) do
-              unquote(body)
-            end
-          end
-      end
-    end
+    __generate_functions(:def, name, clauses)
   end
 
   defmacro mdefp({name, _line, nil}, [do: clauses]) do
+    __generate_functions(:defp, name, clauses)
+  end
+
+  defp __generate_functions(visibility, name, clauses) do
     for {:->, _line, [args, body]} <- clauses do
       case args do
         [{:when, _, when_clause}] -> #[arglist, condition]}] ->
           [ condition | rargs ] = Enum.reverse(when_clause)
           arglist = Enum.reverse(rargs)
-          quote do
-            defp unquote(name)(unquote_splicing(arglist)) when(unquote(condition)) do
+          {_, head, body} = (quote do
+            def unquote(name)(unquote_splicing(arglist)) when(unquote(condition)) do
               unquote(body)
             end
-          end
+          end)
+          {visibility, head, body}
         _ ->
-          quote do
-            defp unquote(name)(unquote_splicing(args)) do
+          {_, head, body} = (quote do
+            def unquote(name)(unquote_splicing(args)) do
               unquote(body)
             end
-          end
+          end)
+          {visibility, head, body}
       end
     end
   end
-
 end

--- a/lib/multi_def.ex
+++ b/lib/multi_def.ex
@@ -1,5 +1,4 @@
 defmodule MultiDef do
-
   @doc """
   Define a function with multiple heads. Use it like this:
 
@@ -41,5 +40,4 @@ defmodule MultiDef do
       end
     end
   end
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Mdef.Mixfile do
   def project do
     [
      app:         :multidef,
-     version:     "0.2.0",
-     elixir:      "~> 0.14",
+     version:     "0.3.0",
+     elixir:      "~> 1.0",
      deps:        [],
      description: description,
      package:     package,
@@ -40,13 +40,11 @@ defmodule Mdef.Mixfile do
   defp package do
     [
       files:        [ "lib", "priv", "mix.exs", "README.md" ],
-      contributors: [ "Dave Thomas <dave@pragprog.org>"],
+      contributors: [ "Dave Thomas <dave@pragprog.org>", "Lennart Fridén <lennart@devl.se>"],
       licenses:     [ "Same as Elixir" ],
       links:        %{
                        "GitHub" => "https://github.com/pragdave/mdef",
                     }
     ]
   end
-
-
 end

--- a/test/multi_def_test.exs
+++ b/test/multi_def_test.exs
@@ -1,30 +1,29 @@
 defmodule MultiDefTest do
   use ExUnit.Case
 
-
   defmodule Test do
 
     import MultiDef
 
     mdef fred do
       { :init, val }   -> fred {:double, val}
-      { :double, val } -> val*2
-      a, b, c when a < b  -> a+b+c
+      { :double, val } -> val * 2
+      a, b, c when a < b  -> a + b + c
     end
   end
 
   test "Single args" do
     assert Test.fred({:init, 3}) == 6
   end
-  
+
   test "Multiple args" do
     assert Test.fred(4, 5, 6) == 15
   end
 
   test "When clauses" do
     assert_raise(
-       FunctionClauseError,
-       "no function clause matching in MultiDefTest.Test.fred/3",
-        fn -> Test.fred(5,4,3) end)
+      FunctionClauseError,
+      "no function clause matching in MultiDefTest.Test.fred/3",
+       fn -> Test.fred(5, 4, 3) end)
   end
 end

--- a/test/multi_def_test.exs
+++ b/test/multi_def_test.exs
@@ -10,6 +10,15 @@ defmodule MultiDefTest do
       { :double, val } -> val * 2
       a, b, c when a < b  -> a + b + c
     end
+
+    def dispatch_to_private(arg) do
+      private(arg)
+    end
+
+    mdefp private do
+      {:add, list} when is_list(list) -> :lists.sum list
+      {:mul, list} -> Enum.reduce(list, &Kernel.*/2)
+    end
   end
 
   test "Single args" do
@@ -25,5 +34,27 @@ defmodule MultiDefTest do
       FunctionClauseError,
       "no function clause matching in MultiDefTest.Test.fred/3",
        fn -> Test.fred(5, 4, 3) end)
+  end
+
+  test "Private function, directly called" do
+    assert_raise(
+      UndefinedFunctionError,
+      "undefined function: MultiDefTest.Test.private/1",
+      fn -> Test.private(:anything) end)
+  end
+
+  test "Private addition function, indirectly called" do
+    assert Test.dispatch_to_private({:add, [1, 2, 3]}) == 6
+  end
+
+  test "Private multiplication function, indirectly called" do
+    assert Test.dispatch_to_private({:mul, [2, 2, 2]}) == 8
+  end
+
+  test "Private function, missing clause" do
+    assert_raise(
+      FunctionClauseError,
+      "no function clause matching in MultiDefTest.Test.private/1",
+      fn -> Test.dispatch_to_private({:add, :not_a_list}) end)
   end
 end


### PR DESCRIPTION
Adds a mdefp macro for generating private functions.
Also bumps the requirements to Elixir 1.0 and bumps the version to 0.3.0.

This is a start, but I've run into a snag when it comes to figuring out a sane way to DRY the macros without adding a private function that pollutes the module the macros are used in. I'm having a hard time fully wrapping my head around Elixir's macros compared to the meta-programming I'm used to coming from Ruby-land. Ideally, I'd like to split the macros into several smaller macros with intention-revealing names that can be used to avoid duplication and pyramid of doom and unreadability going on here.

I believe `defmacrop` can be used to good effect, but I can't seem to figure out how to pass on the parameters from a macro to another without getting lost in a maze of quoting and unquoting. Any ideas and pointers are most welcome!